### PR TITLE
Fix RD108 engine config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -42,7 +42,15 @@
     }
 
     !MODULE[ModuleEngineConfigs],*{}
-
+    
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        origMass = 1.278
+        configuration = RD-108_8D75PS
+        modded = false
+		
     CONFIG
         {
             name = RD-108-8D75
@@ -563,6 +571,7 @@
                 key = 1 257.48
             }
         }
+	}
 
     !RESOURCE,*{}
 


### PR DESCRIPTION
The dev version of the RD108 engine config is missing the ModuleEngineConfigs module before the config descriptions
    MODULE
    {
        name = ModuleEngineConfigs
        type = ModuleEngines
        origMass = 1.278
        configuration = RD-108_8D75PS
        modded = false